### PR TITLE
Config refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ nimcache
 */*/*/nimcache
 
 # Secret details
-config/secret.cfg
+config/nimha_dev.cfg
 
 # Main modules
 nimhapkg/mainmodules/nimha_cron

--- a/config/nimha_default.cfg
+++ b/config/nimha_default.cfg
@@ -1,4 +1,5 @@
-# Rename to secret.cfg
+# Development: config/nimha_dev.cfg
+# Production:  /etc/nimha/nimha.cfg
 
 [Home]
 # Insert your home latitude and longitude

--- a/nimha.nim
+++ b/nimha.nim
@@ -54,15 +54,20 @@ setControlCHook(handler)
 
 
 proc secretCfg() =
-  ## Check if secret.cfg exists
+  ## Check if config file exists
 
-  let secretFn = getAppDir() / "config/secret.cfg"
-  if not fileExists(secretFn):
-    copyFile(getAppDir() & "/config/secret_default.cfg", secretFn)
-    echo "\nYour secret.cfg has been generated at " & secretFn & ". Please fill in your data\n"
+  when defined(dev):
+    let secretFn = getAppDir() / "config/nimha_dev.cfg"
+    if not fileExists(secretFn):
+      copyFile(getAppDir() & "/config/nimha_default.cfg", secretFn)
+      echo "\nThe config file has been generated at " & secretFn & ". Please fill in your data\n"
+  else:
+    if not fileExists("/etc/nimha/nimha.cfg"):
+      echo "\nConfig file /etc/nimha/nimha.cfg does not exists\n"
+      quit(0)
 
 proc updateJsFile() =
-  ## Updates the JS file with Websocket details from secret.cfg
+  ## Updates the JS file with Websocket details from the config file
 
   let wsAddressTo     = "var wsAddress   = \"" & dict.getSectionValue("Websocket","wsAddress") & "\""
   let wsProtocolTo    = "var wsProtocol  = \"" & dict.getSectionValue("Websocket","wsProtocol") & "\""
@@ -89,7 +94,7 @@ proc checkMosquittoBroker() =
     quit()
 
   if dict.getSectionValue("MQTT", "mqttIp") == "":
-    echo "\n\nMosquitto broker: Missing connection details - You have not update secret.cfg with your details. Please insert your data in " & getAppDir() & "/config/secret_default.cfg to continue\n"
+    echo "\n\nMosquitto broker: Missing connection details - You have not update config file with your details.\nPlease insert your data in\n Development: " & getAppDir() & "/config/nimha_dev.cfg\n Production: /etc/nimha/nimha.cfg\n"
     quit()
 
 

--- a/nimha.nimble
+++ b/nimha.nimble
@@ -32,4 +32,5 @@ before install:
   setupTask()
 
 after install:
-  echo "secret.cfg: Please update secret.cfg with your details. The file is located in the nimble package directory at config/secret.cfg\n"
+  echo "Development: Copy config/nimha_default.cfg to config/nimha_dev.cfg\n"
+  echo "Production:  Copy config/nimha_default.cfg to /etc/nimha/nimha.cfg\n"

--- a/nimhapkg/mainmodules/nimha_websocket.nim
+++ b/nimhapkg/mainmodules/nimha_websocket.nim
@@ -67,7 +67,8 @@ for i in countUp(1, 62):
   of 2: localhostKey.add(rand(rDigit))
   else: discard
 let localhostKeyLen = localhostKey.len()
-for fn in [replace(getAppDir(), "/nimhapkg/mainmodules", "") & "/config/secret.cfg"]:
+let configFile = when defined(dev): replace(getAppDir(), "/nimhapkg/mainmodules", "") & "/config/nimha_dev.cfg" else: "/etc/nimha/nimha.cfg"
+for fn in [configFile]:
   # When using setSectionKey formatting and comments are deleted..
   fn.writeFile fn.readFile.replace(re("wsLocalKey = \".*\""), "wsLocalKey = \"" & localhostKey & "\"")
 

--- a/nimhapkg/resources/database/database.nim
+++ b/nimhapkg/resources/database/database.nim
@@ -3,7 +3,7 @@
 import parseCfg, db_sqlite, os, strutils
 import ../../resources/utils/common
 
-let dict = loadConfig(replace(getAppDir(), "/nimhapkg/mainmodules", "") & "/config/secret.cfg")
+let dict = loadConf("database")
 
 let db_user = dict.getSectionValue("Database","user")
 let db_pass = dict.getSectionValue("Database","pass")

--- a/nimhapkg/resources/utils/common.nim
+++ b/nimhapkg/resources/utils/common.nim
@@ -9,9 +9,9 @@ proc loadConf*(modulename: string): Config =
   when defined(dev):
     if modulename == "":
       # main daemon
-      fn = getAppDir() & "/config/secret.cfg"
+      fn = getAppDir() & "/config/nimha_dev.cfg"
     else:
-      fn = replace(getAppDir(), "/nimhapkg/mainmodules", "") & "/config/secret.cfg"
+      fn = replace(getAppDir(), "/nimhapkg/mainmodules", "") & "/config/nimha_dev.cfg"
   else:
     fn = "/etc/nimha/nimha.cfg"
 


### PR DESCRIPTION
Ref: https://github.com/ThomasTJdev/nim_homeassistant/pull/30

1) Renamed config file `secrect.cfg` to `nimha_dev.cfg` for `-d:dev` and `nimha.cfg` for `-d:release`.
2) Added info about where to place `nimha.cfg`
3) Fixed path for DB loading conf